### PR TITLE
Pass lang to backend queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 
 # Visual Studio Code
 .vscode
+*.code-workspace
 
 # Serverless distributions
 .webpack

--- a/functions/apiV2/graphql/resolvers/BillResolver.ts
+++ b/functions/apiV2/graphql/resolvers/BillResolver.ts
@@ -15,9 +15,9 @@ interface IBillQuery {
 }
 
 class CosponsorResolver extends MemberResolver {
-  public fetchObjects (ids: string[], queryFields: rsvr.ProjectionField): Promise<any[]> {
+  public fetchObjects (ids: string[], queryFields: rsvr.ProjectionField, lang?: string): Promise<any[]> {
     const qry = queryFields.compositeFields['member'];
-    return super.fetchObjects(ids, qry);
+    return super.fetchObjects(ids, qry, lang);
   }
 }
 
@@ -50,7 +50,10 @@ export class BillResolver implements rsvr.IResolverFunction<IBillQuery>, IIdObje
         isOneToOne: true
       }
     },
-    gqlOnlyFields: ['prefetchIds', 'billCode']
+    gqlOnlyFields: ['prefetchIds', 'billCode'],
+    remappedFields: {
+      'gist': 'summary'
+    }
   });
 
   public resolve ({lang, ids, congress}: IBillQuery, queryFields: rsvr.ProjectionField) {
@@ -62,7 +65,7 @@ export class BillResolver implements rsvr.IResolverFunction<IBillQuery>, IIdObje
     if (isPrefetch) {
       return this.prefetchIds({ congress });
     } else {
-      return this.fetchObjects(ids, queryFields);
+      return this.fetchObjects(ids, queryFields, lang);
     }
   }
 
@@ -81,7 +84,7 @@ export class BillResolver implements rsvr.IResolverFunction<IBillQuery>, IIdObje
       });
   }
 
-  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField): Promise<any[]> {
+  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField, lang?: string): Promise<any[]> {
     const fLog = this.logger.in('fetchBills');
 
     // if querying 'billCode', then we need to query 'billType.display' && 'billNumber' field
@@ -94,7 +97,7 @@ export class BillResolver implements rsvr.IResolverFunction<IBillQuery>, IIdObje
     }
 
     fLog.log(`\nids = ${JSON.stringify(ids)}\nqueryFields = ${JSON.stringify(queryFields.toJSON())}`);
-    let bills = await this.helper.fetchObjects(ids, queryFields);
+    let bills = await this.helper.fetchObjects(ids, queryFields, lang);
     return this.processPostGenerateFields(bills, queryFields);
   }
 

--- a/functions/apiV2/graphql/resolvers/BillTypeResolver.ts
+++ b/functions/apiV2/graphql/resolvers/BillTypeResolver.ts
@@ -5,7 +5,7 @@ import * as rsvr from './ResolverRegistration';
 import * as _ from 'lodash';
 
 export class BillTypeResolver implements IIdObjectsFetcher {
-  public fetchObjects (ids: string[], queryFields: rsvr.ProjectionField): Promise<any[]> {
+  public fetchObjects (ids: string[], queryFields: rsvr.ProjectionField, lang?: string): Promise<any[]> {
     const fields = queryFields.plainFields;
     const objs = _.map(ids, k => _.pick(billTypeMeta[k], fields));
     return Promise.resolve(objs);

--- a/functions/apiV2/graphql/resolvers/MemberResolver.ts
+++ b/functions/apiV2/graphql/resolvers/MemberResolver.ts
@@ -29,7 +29,8 @@ export class MemberResolver implements  rsvr.IResolverFunction<IMemberQuery>, II
       'cosponsorProperty': {
         apiField: 'cosponsoredBills#date'
       }
-    }
+    },
+    remappedFields: {}
   });
 
   public resolve ({lang, ids, congress, states}: IMemberQuery, queryFields: rsvr.ProjectionField) {
@@ -41,7 +42,7 @@ export class MemberResolver implements  rsvr.IResolverFunction<IMemberQuery>, II
     if (isPrefetch) {
       return this.prefetchIds({ congress, states });
     } else {
-      return this.fetchObjects(ids, queryFields);
+      return this.fetchObjects(ids, queryFields, lang);
     }
   }
 
@@ -61,7 +62,7 @@ export class MemberResolver implements  rsvr.IResolverFunction<IMemberQuery>, II
       });
   }
 
-  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField): Promise<any[]> {
+  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField, lang?: string): Promise<any[]> {
     const fLog = this.logger.in('fetchObjects');
     fLog.log(`\nids = ${JSON.stringify(ids)}\nqueryFields = ${JSON.stringify(queryFields.toJSON())}`);
 
@@ -85,7 +86,7 @@ export class MemberResolver implements  rsvr.IResolverFunction<IMemberQuery>, II
       queryFields.setField('congressRoles', qryRole);
     }
 
-    let members = await this.helper.fetchObjects(ids, queryFields);
+    let members = await this.helper.fetchObjects(ids, queryFields, lang);
     members && (members = _.filter(members, m => m));
     return this.processPostGenerateFields(members, queryFields);
   }

--- a/functions/apiV2/graphql/resolvers/TagResolver.ts
+++ b/functions/apiV2/graphql/resolvers/TagResolver.ts
@@ -11,12 +11,13 @@ export class TagResolver implements IIdObjectsFetcher {
       'tag': {
         apiField: 'name'
       }
-    }
+    },
+    remappedFields: {}
   });
 
-  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField): Promise<any[]> {
+  public async fetchObjects (ids: string[], queryFields: rsvr.ProjectionField, lang?: string): Promise<any[]> {
     const fLog = this.logger.in('fetchObjects');
     fLog.log(`\nids = ${JSON.stringify(ids)}\nqueryFields = ${JSON.stringify(queryFields.toJSON())}`);
-    return await this.helper.fetchObjects(ids, queryFields);
+    return await this.helper.fetchObjects(ids, queryFields, lang);
   }
 }

--- a/functions/apiV2/graphql/schema/types.ts
+++ b/functions/apiV2/graphql/schema/types.ts
@@ -191,7 +191,8 @@ const bill = gql`
     sponsor: Member,
     cosponsors: [Cosponsor],
     tags: [Tag],
-    articles: [Article]
+    articles: [Article],
+    gist: String
   }
 
   type Cosponsor {


### PR DESCRIPTION
- Respect `lang` param when making backend queries
- Support field name remapping between graphql and backend. For example, in a Bill graphql object:
  - `summary` is pulled from S3
  - `gist` (new field!) is pulled from backend field `summary`
